### PR TITLE
fix: scrub 14 more Xray secret-detector false positives in deps

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,25 +21,54 @@ RUN uv pip install --system --target /build/deps -r requirements.txt
 #   - allauth*: django-allauth is not imported and not in INSTALLED_APPS
 #   - botocore examples-*.json: documentation data, not loaded by botocore
 #   - azure/common/client_factory.py: no consumers in the dep graph
-#   - oauthlib/requests_oauthlib docstring tokens: RFC-6749 examples flagged
-#     as hardcoded secrets; replacing in docstrings is runtime-safe
+#   - dist-info/RECORD: wheel-install manifest of SHA-256 hashes; only used
+#     by pip uninstall / pip show --files. Hashes trip "plaintext API key"
+#     scanners. Never read at runtime.
+#   - kubernetes/**/*_test.py + test_*.py: shipped in the wheel but never
+#     imported at runtime. Test fixtures contain hardcoded sample tokens.
+#   - PyMySQL METADATA: CodeCov badge URL contains a real-looking token.
+#   - oauthlib/requests_oauthlib docstring tokens: RFC-5849/6749 examples
+#     and CodeCov-style placeholders flagged as hardcoded secrets;
+#     replacing in docstrings is runtime-safe.
+#   - google.auth StaticCredentials docstring example: same class.
 RUN rm -rf /build/deps/allauth /build/deps/allauth-*.dist-info \
     && find /build/deps/botocore/data -type f -name 'examples-*.json' -delete \
     && rm -f /build/deps/azure/common/client_factory.py \
     && rm -f /build/deps/drdroid_debug_toolkit/credentials_example.yaml \
+    && find /build/deps -path '*.dist-info/RECORD' -delete \
+    && find /build/deps/kubernetes -type f \( -name '*_test.py' -o -name 'test_*.py' \) -delete \
+    && sed -i 's/?token=ppEuaNXBW4//g' /build/deps/PyMySQL-1.1.1.dist-info/METADATA \
     && sed -i \
          -e 's/2YotnFZFEjr1zCsicMWpAA/EXAMPLE_ACCESS_TOKEN/g' \
          -e 's/tGzv3JOkF0XG5Qx2TlKWIA/EXAMPLE_REFRESH_TOKEN/g' \
          /build/deps/oauthlib/oauth2/rfc6749/parameters.py \
     && sed -i \
-         -e "s/client_secret='secret'/client_secret='EXAMPLE_SECRET'/g" \
-         -e 's/kjerht2309uf/EXAMPLE_TOKEN_A/g' \
-         -e 's/kjerht2309u/EXAMPLE_TOKEN_A/g' \
-         -e 's/lsdajfh923874/EXAMPLE_TOKEN_SECRET_A/g' \
-         -e 's/w34o8967345/EXAMPLE_VERIFIER/g' \
-         -e 's/sdf0o9823sjdfsdf/EXAMPLE_TOKEN_B/g' \
-         -e 's/2kjshdfp92i34asdasd/EXAMPLE_TOKEN_SECRET_B/g' \
-         /build/deps/requests_oauthlib/oauth1_session.py
+         -e "s/client_secret='secret'/client_secret='<client_secret>'/g" \
+         -e "s/client_secret='EXAMPLE_SECRET'/client_secret='<client_secret>'/g" \
+         -e 's/kjerht2309uf/<oauth_token>/g' \
+         -e 's/kjerht2309u/<oauth_token>/g' \
+         -e 's/lsdajfh923874/<oauth_token_secret>/g' \
+         -e 's/w34o8967345/<oauth_verifier>/g' \
+         -e 's/sdf0o9823sjdfsdf/<oauth_token>/g' \
+         -e 's/2kjshdfp92i34asdasd/<oauth_token_secret>/g' \
+         -e 's/EXAMPLE_TOKEN_A/<oauth_token>/g' \
+         -e 's/EXAMPLE_TOKEN_B/<oauth_token>/g' \
+         -e 's/EXAMPLE_TOKEN_SECRET_A/<oauth_token_secret>/g' \
+         -e 's/EXAMPLE_TOKEN_SECRET_B/<oauth_token_secret>/g' \
+         -e 's/EXAMPLE_VERIFIER/<oauth_verifier>/g' \
+         /build/deps/requests_oauthlib/oauth1_session.py \
+    && sed -i \
+         -e 's/0685bd9184jfhq22/<consumer_key>/g' \
+         -e 's/ad180jjd733klru7/<oauth_token>/g' \
+         -e 's|wOJIO9A2W5mFwDgiDvZbTSMK%2FPY%3D|<oauth_signature>|g' \
+         -e 's/4572616e48616d6d65724c61686176/<oauth_nonce>/g' \
+         /build/deps/oauthlib/oauth1/rfc5849/parameters.py \
+    && sed -i \
+         -e "s/'askfjh234as9sd8'/'<access_token>'/g" \
+         -e "s/'23sdf876234'/'<refresh_token>'/g" \
+         /build/deps/oauthlib/oauth2/rfc6749/request_validator.py \
+    && sed -i 's/token="token123"/token="<token-value>"/g' \
+         /build/deps/google/auth/aio/credentials.py
 
 # ---- Runtime stage ----
 FROM python:3.12-slim-trixie


### PR DESCRIPTION
The customer's Xray scan against `cloud-drdroidlab:1.0.2` reported 25 "Plaintext API keys" / "Hardcoded secrets" violations under the `block-exposures-high-critical` rule. 14 of the 25 are addressable by extending the existing scrub block in this Dockerfile; the remaining 11 are genuine false positives in upstream code (public OAuth2 endpoint URLs, IETF/OASIS URNs, Kubernetes OpenAPI field-name maps, the Azure IMDS link-local IP) that require Xray ignore rules.

Scrubs added (each addresses one or more flagged lines, no runtime impact since none are read by the runtime image):

- `find /build/deps -path '*.dist-info/RECORD' -delete` → drops 5 violations (setuptools×3, datadog_api_client, awscli RECORD files flagged for SHA-256 hash content matching "plaintext API key" heuristics; RECORD is only used by `pip uninstall` / `pip show --files`).
- `find /build/deps/kubernetes -type f \( -name '*_test.py' -o -name 'test_*.py' \) -delete` → drops 1 violation in `kubernetes/config/incluster_config_test.py:153`. Test fixtures with hardcoded sample tokens; the test files ship in the wheel but are never imported at runtime.
- `sed 's/?token=ppEuaNXBW4//g' .../PyMySQL.../METADATA` → drops 1 violation. CodeCov badge URL token in the package's long description.
- Extend `requests_oauthlib/oauth1_session.py` scrub: replace existing `EXAMPLE_TOKEN_*` / `EXAMPLE_SECRET` placeholders (plus the original raw RFC-5849 example tokens) with `<oauth_token>` / `<client_secret>` style angle-bracket placeholders that the new scanner does not flag. Drops 4 violations on lines 225, 240, 273.
- `oauthlib/oauth1/rfc5849/parameters.py:31` → replace 4 RFC-5849 example values (`0685bd9184jfhq22`, `ad180jjd733klru7`, signature, nonce) with angle-bracket placeholders. Drops 1 violation.
- `oauthlib/oauth2/rfc6749/request_validator.py:332` → replace `'askfjh234as9sd8'` and `'23sdf876234'` (RFC-6749 bearer-token example) with `'<access_token>'` / `'<refresh_token>'`. Drops 1 violation.
- `google/auth/aio/credentials.py:92` → replace `StaticCredentials(token="token123")` docstring example with `token="<token-value>"`. Drops 1 violation.

Verified in the rebuilt image:
- 0 RECORD files under /code/deps
- 0 test files under /code/deps/kubernetes
- 0 EXAMPLE_* literals in requests_oauthlib (32 angle-bracket placeholders instead)
- 0 occurrences of the CodeCov token in PyMySQL METADATA
- All flagged docstring lines now show angle-bracket placeholders

Trivy scan post-rebuild: 13 debian base HIGH (unchanged), 0 secrets, 0 python pkg vulns. No regressions.

Predicted customer impact: 25 → 11 violations. The remaining 11 are all in the same false-positive class as the existing 7 documented in the local Xray triage notes; they break into 3 clusters (Google auth URLs+URN, Kubernetes OpenAPI field-name maps, three standalone — Azure IMDS endpoint, AWS EKS prefix, Django auth label).