### PR TITLE
fix: scrub more Xray secret false positives + universal METADATA trun…

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -68,7 +68,23 @@ RUN rm -rf /build/deps/allauth /build/deps/allauth-*.dist-info \
          -e "s/'23sdf876234'/'<refresh_token>'/g" \
          /build/deps/oauthlib/oauth2/rfc6749/request_validator.py \
     && sed -i 's/token="token123"/token="<token-value>"/g' \
-         /build/deps/google/auth/aio/credentials.py
+         /build/deps/google/auth/aio/credentials.py \
+    && find /build/deps -type f -name '*.pyi' -delete \
+    && rm -rf /build/deps/dj_rest_auth/tests \
+    && find /build/deps -path '*.dist-info/METADATA' -exec sh -c \
+         'awk "/^\$/{exit} {print}" "$1" > "$1.tmp" && mv "$1.tmp" "$1"' \
+         _ {} \; \
+    && sed -i \
+         -e 's|"-----BEGIN EC PRIVATE KEY-----\\n<key bytes>\\n-----END EC PRIVATE KEY-----\\n"|"<private-key-pem>"|g' \
+         /build/deps/google/oauth2/gdch_credentials.py \
+    && sed -i \
+         -e 's|http://169.254.169.254/latest/meta-data/placement/availability-zone|<aws-imds-region-url>|g' \
+         -e 's|http://169.254.169.254/latest/meta-data/iam/security-credentials|<aws-imds-credentials-url>|g' \
+         -e 's|http://169.254.169.254/latest/api/token|<aws-imds-token-url>|g' \
+         /build/deps/google/auth/aws.py \
+    && sed -i \
+         -e 's|"https://database.windows.net/"|"<azure-sql-token-url>"|g' \
+         /build/deps/sqlalchemy/dialects/mssql/pyodbc.py
 
 # ---- Runtime stage ----
 FROM python:3.12-slim-trixie


### PR DESCRIPTION
…cation

Adds a second round of scrubs in response to a fresh customer Xray scan that surfaced new findings the first round of fixes didn't address. Local `jf docker scan --secrets` against trialwyikk8 (same engine the customer's entplus.jfrog.io uses) drops from the original 144 customer violations to 59 residual ignore-rule items.

What's new in this commit (cumulative deltas vs the first scrub round):

- Strip Python type-stub `.pyi` files from /code/deps. They are read by type checkers and IDEs only, never loaded at runtime. Generated proto stubs (`_pb2.pyi`) contain long string literals that trip secret detectors. (Drops `drdroid_debug_toolkit/.../api_pb2.pyi` finding.)
- `rm -rf /build/deps/dj_rest_auth/tests` — wheel ships its test suite with sample passwords inside; never imported at runtime. (Drops the `dj_rest_auth/tests/test_api.py:250` finding.)
- Universal METADATA truncation — keep only the structured headers (`Name:`, `Version:`, `Requires-Dist:`, etc.) by truncating each `dist-info/METADATA` file at the first blank line. The long-form description body (which contains README markdown with CodeCov badge tokens, JWT examples, link-reference URLs) is what trips detectors. Verified `importlib.metadata.version("pyjwt")` still returns 2.12.1 after truncation; vpc-agent code does not call `importlib.metadata` for description access. Generic — applies to all 165 dist-info METADATA files in the image. Replaces the previous targeted `azure_identity / dj_database_url / pyjwt` truncation block.
- `google/oauth2/gdch_credentials.py` docstring example: replace the `-----BEGIN EC PRIVATE KEY-----\n<key bytes>\n-----END EC PRIVATE KEY-----` placeholder with `<private-key-pem>` since the BEGIN/END PEM markers themselves trip detectors.
- `google/auth/aws.py` docstring example: replace the three `http://169.254.169.254/latest/...` IMDS URLs with placeholders so the docstring stops tripping IP-literal heuristics.
- `sqlalchemy/dialects/mssql/pyodbc.py` docstring example: replace `https://database.windows.net/` Azure SQL token URL with a placeholder.

The remaining 59 secrets in the v3 image are all third-party variable identifiers (TOKEN_*/SAML_*/_AWS_*/secret_*/password) and OpenAPI field-name maps that cannot be renamed without breaking runtime imports, K8s API serialization, msal's WS-Trust parsing, or Django's i18n labels. Documented in the local triage notes.