### PR TITLE
ci: run manual-release workflow on warp 16x runner

### DIFF
--- a/.github/workflows/manual-release.yaml
+++ b/.github/workflows/manual-release.yaml
@@ -31,7 +31,7 @@ env:
 
 jobs:
   release:
-    runs-on: ubuntu-latest
+    runs-on: warp-ubuntu-latest-x64-16x-spot
     permissions:
       contents: read
       packages: write


### PR DESCRIPTION
## Summary

- Bumps the runner for the \`release\` job in \`.github/workflows/manual-release.yaml\` from \`ubuntu-latest\` (2-core, 7GB) to \`warp-ubuntu-latest-x64-16x-spot\` (the same pool used by the \`setup\` job in \`build-and-push.yaml\`).
- The release job builds a multi-arch image (\`linux/amd64,linux/arm64\`) and pushes to DockerHub + GHCR; on the alpine base several Python deps compile from source, so the stock runner is the bottleneck.
- No functional change to what gets built or where it gets pushed.

## Test plan

- [ ] Trigger \`Manual Release\` from the Actions tab with a test version (or wait for the next intentional release) and confirm the runner shows as \`warp-ubuntu-latest-x64-16x-spot\` in the run logs.
- [ ] Confirm the resulting images appear in DockerHub + GHCR with the expected tags.
- [ ] Confirm the helm chart push to \`oci://ghcr.io/drdroidlab/charts\` still succeeds when \`push_helm_chart=true\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)