### PR TITLE
chore: bump redis image to 8-alpine

### DIFF
--- a/helm/charts/redis/templates/deployment.yaml
+++ b/helm/charts/redis/templates/deployment.yaml
@@ -26,7 +26,7 @@ spec:
       {{- end }}
       containers:
         - name: redis
-          image: redis:7-alpine
+          image: redis:8-alpine
           ports:
             - containerPort: 6379
           resources:

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -73,4 +73,4 @@ celery-worker:
         memory: "1536Mi"
 
 redis:
-  image: redis:7.2
+  image: redis:8-alpine


### PR DESCRIPTION
## Summary
- Bump redis image from `redis:7-alpine` / `redis:7.2` to `redis:8-alpine` in the helm chart deployment and `values.yaml`.

## Test plan
- [x] Helm chart renders cleanly: `helm template helm/`
- [x] Redis pod comes up healthy and accepts connections from celery worker/beat
- [x] Celery beat/worker tasks continue to run end-to-end against the new redis