### PR TITLE
bumped toolkit revision - fix(kubectl): quote-aware pipeline parsing …

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -148,5 +148,5 @@ wcwidth==0.2.13
 websocket-client==1.8.0
 yarl==1.12.1
 zstandard==0.23.0
-# Latest version of drdroid-debug-toolkit -> added logql cleanup
+# Latest version of drdroid-debug-toolkit -> fix(kubectl): quote-aware pipeline parsing in execute_command
 git+https://github.com/DrDroidLab/drdroid-debug-toolkit.git@master


### PR DESCRIPTION
…in execute_command