### PR TITLE
Grant read access to HorizontalPodAutoscalers in cluster role

### DIFF
--- a/helm/templates/clusterRole.yaml
+++ b/helm/templates/clusterRole.yaml
@@ -43,6 +43,12 @@ rules:
       - "list"
       - "watch"
 
+  # Autoscaling
+  - apiGroups: ["autoscaling"]
+    resources:
+      - horizontalpodautoscalers
+    verbs: ["get", "list", "watch"]
+
   # Batch jobs
   - apiGroups: ["batch"]
     resources:


### PR DESCRIPTION
Adds the autoscaling API group to drdroid-k8s-cluster-role so the VPC agent can query HPAs. Read-only, matching the other rules. Needs a helm upgrade to apply.